### PR TITLE
Add configuration for kitchen/berkshelf/serverspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,5 +13,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[syslog-ng::default]
+      - recipe[syslog-ng_test::default]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+  - name: centos-6.7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[syslog-ng::default]
+    attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source "https://supermarket.chef.io"
 
 metadata
+
+group :integration do
+  cookbook 'syslog-ng_test', path: 'test/fixtures/cookbooks/syslog-ng_test'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+
+# Uncomment these lines if you want to live on the Edge:
+#
+# group :development do
+#   gem "berkshelf", github: "berkshelf/berkshelf"
+#   gem "vagrant", github: "mitchellh/vagrant", tag: "v1.6.3"
+# end
+#
+# group :plugins do
+#   gem "vagrant-berkshelf", github: "berkshelf/vagrant-berkshelf"
+#   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
+# end
+
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          "Apache 2.0"
 description      "Installs/Configures syslog-ng"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.4.0"
+
+depends 'yum-epel', '~> 0.6.3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+if platform_family?('rhel')
+  include_recipe 'yum-epel'
+end
+
 package "syslog-ng"
 
 cookbook_file "#{node[:syslog_ng][:config_dir]}/syslog-ng.conf" do

--- a/test/fixtures/cookbooks/syslog-ng_test/README.md
+++ b/test/fixtures/cookbooks/syslog-ng_test/README.md
@@ -1,0 +1,4 @@
+# syslog-ng_test
+
+Installs syslog-ng with some commonly used options.
+

--- a/test/fixtures/cookbooks/syslog-ng_test/metadata.rb
+++ b/test/fixtures/cookbooks/syslog-ng_test/metadata.rb
@@ -1,0 +1,7 @@
+name             'syslog-ng_test'
+license          'All rights reserved'
+description      'Installs/Configures syslog-ng_test'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'syslog-ng'

--- a/test/fixtures/cookbooks/syslog-ng_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/syslog-ng_test/recipes/default.rb
@@ -1,0 +1,30 @@
+
+include_recipe "syslog-ng"
+
+syslog_ng_source "source_foo" do
+  index "02"
+  host "127.0.0.1"
+  port "514"
+end
+
+syslog_ng_file "application_foo" do
+  index "03"
+  source_name "source_foo"
+  days_uncompressed "7"
+  log_base "/var/applogs"
+  log_name "default.log"
+end
+
+syslog_ng_filter "warnings" do
+  index  "04"
+  filter "level(warning)"
+end
+
+syslog_ng_forwarder "application_foo_warnings" do
+  index "05"
+  source_name "source_foo"
+  filter_name "warnings"
+  destination_host "example.com"
+  destination_port "514"
+  destination_protocol "udp"
+end

--- a/test/integration/default/serverspec/syslog-ng_daemon_spec.rb
+++ b/test/integration/default/serverspec/syslog-ng_daemon_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe "Syslog-ng Daemon" do
+
+  it "is listening on port 514" do
+    expect(port(514)).to be_listening
+  end
+
+  it "has a running service of syslog-ng" do
+    expect(service("syslog-ng")).to be_running
+  end
+
+end


### PR DESCRIPTION
Add configurations for modern test tools.

Also adds yum-epel dependency for RHEL as a user convenience and in order to get the tests to complete.  Let me know if you think this would be better to leave out and I'll move it into the test cookbook.
